### PR TITLE
Add subtasks APIs (queries + mutations)

### DIFF
--- a/apps/server/prisma/migrations/20240319075854_add_subtasks_order/migration.sql
+++ b/apps/server/prisma/migrations/20240319075854_add_subtasks_order/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Task" ADD COLUMN     "subtasksOrder" INTEGER[];

--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -99,6 +99,8 @@ model Task {
   date              DateTime   @db.Date
   /// The length of time the task is expected to take.
   durationInMinutes Int?
+  /// Order of the subtasks in the task
+  subtasksOrder     Int[]
 
   /// The item linked to the task
   item   Item? @relation(fields: [itemId], references: [id])

--- a/apps/server/src/graphql/Day.ts
+++ b/apps/server/src/graphql/Day.ts
@@ -28,7 +28,7 @@ export const DayType = builder.prismaNode("Day", {
         const order = dayInfo?.tasksOrder ?? day.tasksOrder; // day.tasksOrder might be outdated if the tasksOrder was updated in another request
         const tasks = await prisma.task.findMany({
           ...query,
-          where: { date: day.date },
+          where: { date: day.date, parentTaskId: null },
         });
         const tasksOrdered = tasks.sort((a, b) => {
           return order.indexOf(a.id) - order.indexOf(b.id);

--- a/apps/server/src/graphql/Task.ts
+++ b/apps/server/src/graphql/Task.ts
@@ -341,14 +341,20 @@ Any other scenario is not possible by nature of the app, where tasks:
           // and the position of the task in the day
           await tx.task.update({
             where: { id: task.id },
-            data: { status: newStatus, completedAt: newStatus === "DONE" ? new Date() : null,
-            subtasks: {
-              updateMany: {
-                where: { parentTaskId: task.id },
-                data: { status: newStatus, completedAt: newStatus === "DONE" ? new Date() : null },
+            data: {
+              status: newStatus,
+              completedAt: newStatus === "DONE" ? new Date() : null,
+              subtasks: {
+                updateMany: {
+                  where: { parentTaskId: task.id },
+                  data: {
+                    status: newStatus,
+                    completedAt: newStatus === "DONE" ? new Date() : null,
+                  },
+                },
               },
-            }
-          }});
+            },
+          });
           const newTasksOrder = originalDay.tasksOrder.filter((id) => id !== task.id);
           if (newStatus === "TODO") {
             newTasksOrder.splice(0, 0, task.id);
@@ -455,7 +461,8 @@ Any other scenario is not possible by nature of the app, where tasks:
                     where: { parentTaskId: task.id },
                     data: {
                       status: newStatus,
-                      completedAt: newStatus === "DONE" ? dayjs(task.date).endOf("day").toDate() : null,
+                      completedAt:
+                        newStatus === "DONE" ? dayjs(task.date).endOf("day").toDate() : null,
                     },
                   },
                 },
@@ -570,7 +577,8 @@ When the task is:
                       where: { parentTaskId: task.id },
                       data: {
                         status: newStatus,
-                        completedAt: newStatus === "DONE" ? dayjs(newDate).endOf("day").toDate() : null,
+                        completedAt:
+                          newStatus === "DONE" ? dayjs(newDate).endOf("day").toDate() : null,
                       },
                     },
                   },

--- a/apps/server/src/graphql/Task.ts
+++ b/apps/server/src/graphql/Task.ts
@@ -28,6 +28,7 @@ export const TaskType = builder.prismaNode("Task", {
     }),
     tags: t.relation("tags"),
     pluginDatas: t.relation("pluginDatas"),
+    subtasks: t.relation("subtasks"),
   }),
 });
 

--- a/apps/server/src/graphql/Task.ts
+++ b/apps/server/src/graphql/Task.ts
@@ -564,7 +564,7 @@ When the task is:
 
 // -------------------- Task subtasks mutations --------------------
 
-builder.mutationField("createSubtask", (t) => 
+builder.mutationField("createSubtask", (t) =>
   t.prismaFieldWithInput({
     type: "Task",
     description: `Create a new subtask.`,
@@ -573,13 +573,16 @@ builder.mutationField("createSubtask", (t) =>
       taskId: t.input.globalID({ required: true, description: "The Relay ID of the parent task." }),
     },
     resolve: async (query, _, args) => {
-      const parentTask = await prisma.task.findUnique({ where: { id: parseInt(args.input.taskId.id) } });
+      const parentTask = await prisma.task.findUnique({
+        where: { id: parseInt(args.input.taskId.id) },
+      });
       if (!parentTask) {
         throw new GraphQLError(`Parent task with ID ${args.input.taskId.id} not found.`, {
           extensions: {
             code: "PARENT_TASK_NOT_FOUND",
-            userFriendlyMessage: "The parent task was not found. Please try refreshing the page and try again."
-          }
+            userFriendlyMessage:
+              "The parent task was not found. Please try refreshing the page and try again.",
+          },
         });
       }
       return prisma.task.create({
@@ -588,9 +591,9 @@ builder.mutationField("createSubtask", (t) =>
           title: args.input.title,
           status: "TODO",
           parentTask: { connect: { id: parseInt(args.input.taskId.id) } },
-          day: {connect: {date: parentTask.date}},
+          day: { connect: { date: parentTask.date } },
         },
       });
     },
   }),
-)
+);

--- a/apps/web/src/components/TaskCard.tsx
+++ b/apps/web/src/components/TaskCard.tsx
@@ -37,6 +37,7 @@ import { toast } from "@flowdev/ui/Toast";
 import { RenderTaskCardDetails } from "./RenderTaskCardDetails";
 import { RenderTaskCardActions } from "./RenderTaskCardActions";
 import { TaskCardSubtasks_task$key } from "../relay/__generated__/TaskCardSubtasks_task.graphql";
+import { TaskCardSubtask_task$key } from "../relay/__generated__/TaskCardSubtask_task.graphql";
 
 type TaskCardProps = {
   task: TaskCard_task$key;
@@ -119,9 +120,27 @@ const TaskCardSubtasks = (props: TaskCardSubtasksProps) => {
         id
         subtasks {
           id
-          title
-          status
+          ...TaskCardSubtask_task
         }
+      }
+    `,
+    props.task,
+  );
+
+  return (
+    <div className="flex flex-col gap-2">
+      {task?.subtasks?.map((subtask) => <TaskCardSubtask key={subtask.id} task={subtask} />)}
+    </div>
+  );
+};
+
+const TaskCardSubtask = (props: {task: TaskCardSubtask_task$key}) => {
+  const task = useFragment(
+    graphql`
+      fragment TaskCardSubtask_task on Task {
+        id
+        title
+        status
       }
     `,
     props.task,
@@ -178,20 +197,26 @@ const TaskCardSubtasks = (props: TaskCardSubtasksProps) => {
     </CardActionButton>
   );
 
+  const longTitle = task.title.length > 24;
+
   return (
-    <div className="flex flex-col gap-2">
-      {task?.subtasks?.map((subtask) => (
-        <div className="flex gap-2">
-          <div className="flex gap-2">
-            {subtask.status === "DONE" ? undoDoneButton : doneButton}
-            {subtask.status === "CANCELED" ? undoCancelButton : cancelButton}
-          </div>
-          <div>{subtask.title}</div>
-        </div>
-      ))}
+    <div className={tw("flex gap-2", longTitle && "min-h-[3.25em]")}>
+      <div className={tw("flex gap-2 relative", longTitle && "flex-col gap-1")}>
+        {task.status === "TODO" ? (
+          <>
+            {doneButton}
+            {cancelButton}
+          </>
+        ) : task.status === "DONE" ? (
+          undoDoneButton
+        ) : (
+          undoCancelButton
+        )}
+      </div>
+      <div>{task.title}</div>
     </div>
-  );
-};
+  )
+}
 
 type TaskCardActionsProps = {
   task: TaskCardActions_task$key;

--- a/apps/web/src/components/TaskCard.tsx
+++ b/apps/web/src/components/TaskCard.tsx
@@ -134,7 +134,7 @@ const TaskCardSubtasks = (props: TaskCardSubtasksProps) => {
   );
 };
 
-const TaskCardSubtask = (props: {task: TaskCardSubtask_task$key}) => {
+const TaskCardSubtask = (props: { task: TaskCardSubtask_task$key }) => {
   const task = useFragment(
     graphql`
       fragment TaskCardSubtask_task on Task {
@@ -215,8 +215,8 @@ const TaskCardSubtask = (props: {task: TaskCardSubtask_task$key}) => {
       </div>
       <div>{task.title}</div>
     </div>
-  )
-}
+  );
+};
 
 type TaskCardActionsProps = {
   task: TaskCardActions_task$key;

--- a/apps/web/src/components/TaskCard.tsx
+++ b/apps/web/src/components/TaskCard.tsx
@@ -36,7 +36,6 @@ import { TaskCardDeleteTaskMutation } from "../relay/__generated__/TaskCardDelet
 import { toast } from "@flowdev/ui/Toast";
 import { RenderTaskCardDetails } from "./RenderTaskCardDetails";
 import { RenderTaskCardActions } from "./RenderTaskCardActions";
-import { TaskCardSubtasks_task$key } from "../relay/__generated__/TaskCardSubtasks_task.graphql";
 import { TaskCardSubtask_task$key } from "../relay/__generated__/TaskCardSubtask_task.graphql";
 
 type TaskCardProps = {
@@ -52,8 +51,11 @@ export const TaskCard = (props: TaskCardProps) => {
         title
         status
         completedAt # updates the CalendarList component to add checkmark at the time of completion
+        subtasks {
+          id
+          ...TaskCardSubtask_task
+        }
         ...RenderTaskCardDetails_task
-        ...TaskCardSubtasks_task
         ...TaskCardActions_task
         ...TaskTitle_task
       }
@@ -89,7 +91,9 @@ export const TaskCard = (props: TaskCardProps) => {
           )}
         >
           <TaskTitle task={task} />
-          <TaskCardSubtasks task={task} />
+          <div className="flex flex-col gap-2">
+            {task?.subtasks?.map((subtask) => <TaskCardSubtask key={subtask.id} task={subtask} />)}
+          </div>
           <RenderTaskCardDetails task={task} />
           <TaskCardActions task={task} />
         </div>
@@ -108,31 +112,6 @@ const taskCardUpdateTaskStatusMutation = graphql`
     }
   }
 `;
-
-type TaskCardSubtasksProps = {
-  task: TaskCardSubtasks_task$key;
-};
-
-const TaskCardSubtasks = (props: TaskCardSubtasksProps) => {
-  const task = useFragment(
-    graphql`
-      fragment TaskCardSubtasks_task on Task {
-        id
-        subtasks {
-          id
-          ...TaskCardSubtask_task
-        }
-      }
-    `,
-    props.task,
-  );
-
-  return (
-    <div className="flex flex-col gap-2">
-      {task?.subtasks?.map((subtask) => <TaskCardSubtask key={subtask.id} task={subtask} />)}
-    </div>
-  );
-};
 
 const TaskCardSubtask = (props: { task: TaskCardSubtask_task$key }) => {
   const task = useFragment(

--- a/apps/web/src/relay/schema.graphql
+++ b/apps/web/src/relay/schema.graphql
@@ -198,6 +198,9 @@ type Mutation {
   createOrUpdateNote(input: MutationCreateOrUpdateNoteInput!): Note!
   createRoutine(input: MutationCreateRoutineInput!): Routine!
 
+  """Create a new subtask."""
+  createSubtask(input: MutationCreateSubtaskInput!): Task!
+
   """Create a new task."""
   createTask(input: MutationCreateTaskInput!): Task!
 
@@ -229,6 +232,9 @@ type Mutation {
   Logout from the Flow instance using the session token set in the Authorization header.
   """
   logout: Boolean!
+
+  """Make a task a subtask of another task."""
+  makeTaskSubtaskOf(input: MutationMakeTaskSubtaskOfInput!): Task!
   pluginOperation(input: MutationPluginOperationInput!): PluginOperation
 
   """
@@ -358,6 +364,14 @@ input MutationCreateRoutineInput {
   time: Time!
 }
 
+input MutationCreateSubtaskInput {
+  """The Relay ID of the parent task."""
+  parentTaskId: ID!
+
+  """The title of the subtask."""
+  title: String!
+}
+
 input MutationCreateTaskInput {
   """The actions to be executed after the task is created."""
   actionDatas: [TaskActionDataInput!]
@@ -398,6 +412,14 @@ input MutationInstallPluginInput {
 input MutationLoginInput {
   """The password (unhashed)."""
   password: String!
+}
+
+input MutationMakeTaskSubtaskOfInput {
+  """The Relay ID of the parent task."""
+  parentTaskId: ID!
+
+  """The Relay ID of the task to update."""
+  taskId: ID!
 }
 
 input MutationPluginOperationInput {
@@ -940,6 +962,9 @@ type Task implements Node {
 
   """The status of the task"""
   status: TaskStatus!
+
+  """The subtasks of the task"""
+  subtasks: [Task!]!
 
   """The tags of the task """
   tags: [TaskTag!]!

--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
   },
   "prettier": {
     "printWidth": 100
+  },
+  "resolutions": {
+    "vite": "4.5.2"
   }
 }


### PR DESCRIPTION
# Overview

- Adds subtasks order as decided in https://github.com/richardguerre/flow/issues/32

# Todo

- [x] Add `Tasks.subtasks` field.
- [x] Add `makeTaskSubtask` mutation in Task.ts
- [x] Add `createSubtask` mutation
- [x] Show subtasks in the frontend
- [x] Improve UI of subtasks
- [ ] Have a way to drag and drop or add/remove subtasks
- [x] Modify updateTaskStatus and updateTaskDate mutations to ignore subtasks when deciding if it passes the "next day" threshold.